### PR TITLE
feature/spark_parquet_support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,87 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+### Eclipse template
+
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# Eclipse Core
+.project
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+### JDeveloper template
+# default application storage directory used by the IDE Performance Cache feature
+.data/
+
+# used for ADF styles caching
+temp/
+
+# default output directories
+classes/
+deploy/
+javadoc/
+
+# lock file, a part of Oracle Credential Store Framework
+cwallet.sso.lck### Java template
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+.idea/
+metastore_db/
+parquet-rewriter.iml
+spark-warehouse/
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,10 @@
     <groupId>com.factual</groupId>
     <artifactId>parquet-rewriter</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.0</version>
-
+    <version>0.1.1</version>
+    <properties>
+        <hadoop.version>2.6.0-cdh5.13.0</hadoop.version>
+    </properties>
     <build>
         <plugins>
           <plugin>
@@ -26,6 +28,12 @@
           
         </plugins>
     </build>
+    <repositories>
+        <repository>
+            <id>cloudera</id>
+            <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+        </repository>
+    </repositories>
     <dependencies>
         <!--there track spark versions-->
         <dependency>
@@ -48,7 +56,7 @@
             <artifactId>parquet-column</artifactId>
             <version>1.8.2</version>
         </dependency>
-
+        
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
@@ -62,12 +70,12 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.7.0</version>
+            <version>${hadoop.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-common</artifactId>
-            <version>2.7.0</version>
+            <version>${hadoop.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/src/main/java/com/factual/parquet/ParquetBlockMutator.java
+++ b/src/main/java/com/factual/parquet/ParquetBlockMutator.java
@@ -32,14 +32,14 @@ import static org.apache.parquet.hadoop.ParquetOutputFormat.*;
  */
 public class ParquetBlockMutator<T,KT extends Comparable<KT>> implements Closeable {
 
-  ReadSupport<T> readSupport;
-  WriteSupport<T> writeSupport;
+  ReadSupport<? extends T> readSupport;
+  WriteSupport<? super T> writeSupport;
   ParquetFileWriter writer;
   FileMetaData sourceFileMetadata;
-  RecordWriter<T> recordWriter;
-  ParquetRewriter.KeyAccessor<T,KT> keyAccessor;
+  RecordWriter<? super T> recordWriter;
+  ParquetRewriter.KeyAccessor<? super T,KT> keyAccessor;
   PageReadStore pageReadStore;
-  RecordReader<T> recordReader;
+  RecordReader<? extends T> recordReader;
   KT lastKey;
   T lastRecord;
   long blockSize;
@@ -72,10 +72,10 @@ public class ParquetBlockMutator<T,KT extends Comparable<KT>> implements Closeab
           long blockSize,
           PageReadStore readStore,
           FileMetaData fileMetadata,
-          ReadSupport<T> readSupport,
-          WriteSupport<T> writeSupport,
+          ReadSupport<? extends T> readSupport,
+          WriteSupport<? super T> writeSupport,
           ParquetFileWriter fileWriter,
-          ParquetRewriter.KeyAccessor<T,KT> keyAccessor)throws IOException  {
+          ParquetRewriter.KeyAccessor<? super T,KT> keyAccessor)throws IOException  {
 
     this.readSupport = readSupport;
     this.writeSupport = writeSupport;
@@ -90,7 +90,7 @@ public class ParquetBlockMutator<T,KT extends Comparable<KT>> implements Closeab
     if (pageReadStore != null) {
       // initialize a parquet record reader for this page ...
       ReadSupport.ReadContext context = readSupport.init(new InitContext(conf, toSetMultiMap(fileMetadata.getKeyValueMetaData()), sourceFileMetadata.getSchema()));
-      RecordMaterializer<T> recordConverter = readSupport.prepareForRead(conf, fileMetadata.getKeyValueMetaData(), sourceFileMetadata.getSchema(), context);
+      RecordMaterializer<? extends T> recordConverter = readSupport.prepareForRead(conf, fileMetadata.getKeyValueMetaData(), sourceFileMetadata.getSchema(), context);
       ColumnIOFactory ioFactory = new ColumnIOFactory(false);
       MessageColumnIO columnIO = ioFactory.getColumnIO(sourceFileMetadata.getSchema());
       this.recordReader = columnIO.getRecordReader(pageReadStore, recordConverter);

--- a/src/main/java/com/factual/parquet/ParquetRewriter.java
+++ b/src/main/java/com/factual/parquet/ParquetRewriter.java
@@ -54,14 +54,14 @@ public class ParquetRewriter<T,KT extends Comparable<KT>> implements Closeable{
   }
 
   Configuration conf;
-  KeyAccessor<T,KT> keyAccessor;
+  KeyAccessor<? super T,KT> keyAccessor;
   ColumnPath keyPath;
   ParquetFileReader reader;
   ParquetFileWriter writer;
   ArrayList<BlockMetaData>      incomingBlocks;
   ArrayList<Statistics<KT>>   incomingStats = Lists.newArrayList();
-  ReadSupport<T> readSupport;
-  WriteSupport<T> writeSupport;
+  ReadSupport<? extends T> readSupport;
+  WriteSupport<? super T> writeSupport;
   ParquetBlockMutator<T,KT> activeMutableBlock;
   int nextBlockIndex = 0;
   KT lastKey;
@@ -87,10 +87,10 @@ public class ParquetRewriter<T,KT extends Comparable<KT>> implements Closeable{
   public ParquetRewriter(Configuration incomingConf,
                          Path sourceFile,
                          Path destFile,
-                         ReadSupport<T> readSupport,
-                         WriteSupport<T> writeSupport,
+                         ReadSupport<? extends T> readSupport,
+                         WriteSupport<? super T> writeSupport,
                          int optionalRowGroupSize,
-                         KeyAccessor<T,KT> keyAccessor,
+                         KeyAccessor<? super T,KT> keyAccessor,
                          ColumnPath keyPath) throws IOException {
 
     this.conf = new Configuration(incomingConf);

--- a/src/main/java/com/factual/parquet/RecordWriter.java
+++ b/src/main/java/com/factual/parquet/RecordWriter.java
@@ -56,7 +56,7 @@ public class RecordWriter<T> {
   private static final int MAXIMUM_RECORD_COUNT_FOR_CHECK = 10000;
 
   private final ParquetFileWriter parquetFileWriter;
-  private final WriteSupport<T> writeSupport;
+  private final WriteSupport<? super T> writeSupport;
   private final MessageType schema;
   private final long rowGroupSize;
   private long rowGroupSizeThreshold;
@@ -183,7 +183,7 @@ public class RecordWriter<T> {
   public RecordWriter(
           Configuration conf,
           ParquetFileWriter parquetFileWriter,
-          WriteSupport<T> writeSupport,
+          WriteSupport<? super T> writeSupport,
           MessageType schema,
           Map<String, String> extraMetaData,
           long rowGroupSize,


### PR DESCRIPTION
`ParquetReadSupport extends ReadSupport[UnsafeRow]` but `ParquetWriteSupport extends WriteSupport[InternalRow]` and `class UnsafeRow extends InternalRow`. So I change a bunch of generic type to conform this Spark's weirdness. 
cc @ahadrana 